### PR TITLE
have Range and ObservedRange (the later tracks key metadata)

### DIFF
--- a/src/libdeltafs/CMakeLists.txt
+++ b/src/libdeltafs/CMakeLists.txt
@@ -54,6 +54,7 @@ set (deltafs-tests deltafs_api_test.cc
         plfsio/v1/filter_test.cc
         plfsio/v1/filterio_test.cc
         plfsio/v1/pdb_test.cc
+        plfsio/v1/range_test.cc
         plfsio/v1/rangewriter_test.cc
         plfsio/v1/v1_test.cc
         mds_api_test.cc

--- a/src/libdeltafs/plfsio/v1/range_test.cc
+++ b/src/libdeltafs/plfsio/v1/range_test.cc
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2022 Carnegie Mellon University,
+ * Copyright (c) 2022 Triad National Security, LLC, as operator of
+ *     Los Alamos National Laboratory.
+ *
+ * All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file. See the AUTHORS file for names of contributors.
+ */
+
+#include <algorithm>
+#include <inttypes.h>
+
+#include "range.h"
+#include "pdlfs-common/testharness.h"
+
+namespace pdlfs {
+namespace plfsio {
+
+class RangeTest {};
+
+TEST(RangeTest, Range) {
+  Range r;
+  ASSERT_FALSE(r.IsSet());
+  ASSERT_TRUE(r.IsValid());
+
+  r.Set(10.0, 20.0);
+  ASSERT_TRUE(r.IsSet());
+  ASSERT_TRUE(r.IsValid());
+
+  ASSERT_EQ(r.rmin(), 10.0);
+  ASSERT_EQ(r.rmax(), 20.0);
+  ASSERT_FALSE(r.Inside(-10.0));
+  ASSERT_FALSE(r.Inside(0.0));
+  ASSERT_TRUE(r.Inside(10.0));
+  ASSERT_TRUE(r.Inside(15.0));
+  ASSERT_FALSE(r.Inside(20.0));
+  ASSERT_FALSE(r.Inside(25.0));
+
+  r.Extend(10.0, 30.0);
+  ASSERT_EQ(r.rmin(), 10.0);
+  ASSERT_EQ(r.rmax(), 30.0);
+  ASSERT_FALSE(r.Inside(-10.0));
+  ASSERT_FALSE(r.Inside(0.0));
+  ASSERT_TRUE(r.Inside(10.0));
+  ASSERT_TRUE(r.Inside(15.0));
+  ASSERT_TRUE(r.Inside(20.0));
+  ASSERT_TRUE(r.Inside(25.0));
+  ASSERT_FALSE(r.Inside(30.0));
+
+  ASSERT_TRUE(r.IsSet());
+  ASSERT_TRUE(r.IsValid());
+  r.Reset();
+  ASSERT_FALSE(r.IsSet());
+  ASSERT_TRUE(r.IsValid());
+}
+
+TEST(RangeTest, ObservedRange) {
+  ObservedRange o, o2;
+
+  ASSERT_FALSE(o.IsSet());
+  ASSERT_TRUE(o.IsValid());
+  o.Set(10.0, 20.0);
+  ASSERT_TRUE(o.IsSet());
+  ASSERT_TRUE(o.IsValid());
+
+  o.Observe(20.0);
+  o.Observe(14.0);
+  o.Observe(50.0);
+  ASSERT_EQ(o.rmin(), 10.0);
+  ASSERT_EQ(o.rmax(), 20.0);
+  ASSERT_EQ(o.smallest(), 14.0);
+  ASSERT_EQ(o.largest(), 50.0);
+  ASSERT_EQ(o.num_items(), 3);
+  ASSERT_EQ(o.num_items_oob(), 2);
+
+  o.ClearObservations();
+  o.Observe(19.0);
+  o.Observe(16.0);
+  o.Observe(48.0);
+  ASSERT_EQ(o.rmin(), 10.0);
+  ASSERT_EQ(o.rmax(), 20.0);
+  ASSERT_EQ(o.smallest(), 16.0);
+  ASSERT_EQ(o.largest(), 48.0);
+  ASSERT_EQ(o.num_items(), 3);
+  ASSERT_EQ(o.num_items_oob(), 1);
+
+  o2.Set(5.0, 15.0);
+  o2.Observe(6.0);
+  o2.Observe(16.0);
+  o.MergeRangeObservations(&o2);
+  ASSERT_EQ(o.rmin(), 5.0);
+  ASSERT_EQ(o.rmax(), 20.0);
+  ASSERT_EQ(o.smallest(), 6.0);
+  ASSERT_EQ(o.largest(), 48.0);
+  ASSERT_EQ(o.num_items(), 5);
+  ASSERT_EQ(o.num_items_oob(), 2);
+}
+
+}  // namespace plfsio
+}  // namespace pdlfs
+
+int main(int argc, char** argv) {
+  return ::pdlfs::test::RunAllTests(&argc, &argv);
+}

--- a/src/libdeltafs/plfsio/v1/range_writer.h
+++ b/src/libdeltafs/plfsio/v1/range_writer.h
@@ -97,8 +97,8 @@ class RangeWriter {
   // to be replaced with empty ones), then it retires the current
   // expected range to the set of previous ranges (discarding the
   // oldest previous range we currently have).   we set the
-  // current range to rmin and rmax with the requested number of
-  // subpartitions.
+  // current range to rmin and rmax (inclusive and exclusive,
+  // respectively) with the requested number of subpartitions.
   //
   Status UpdateBounds(const float rmin, const float rmax);
 
@@ -142,7 +142,8 @@ class RangeWriter {
   // belongs to.  we order the bactive_[] array so that all nsubpart_
   // blocks are first, followed by the nprevious_ block covering
   // previous ranges (oldest last).  if we can't find a good match,
-  // we choose the oldest previous block.  lock should be held.
+  // we choose the oldest previous block and deal with it.
+  // lock should be held.
   //
   int FindBlock(float key) {
     mu_.AssertHeld();


### PR DESCRIPTION
A Range has a min (inclusive) and max (exclusive) and can be Set() or Extended().  You can test to see if it IsSet() or IsValid(), and you can test to see if a point is Inside() the Range.

An ObservedRange does what range does, but also has an Observe(value) function that tracks the smallest and largest values inserted in the ObservedRange.  It also tracks the number of items observed and how many of those items were out of bounds.

ordered builder now only needs one ObservedRange to track expected range and observed values.  partition manifest writer can also use ObservedRange to track overall metadata in an manifest_obrange_ object.

add unit test for range.h